### PR TITLE
Add getToken to createAuthProvider response

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,10 @@ export const createAuthProvider = <T>({
     const logout = () => {
         tp.setToken(null);
     };
+                                          
+    const getToken = async () => {
+        return await tp.getToken();
+    };
 
     const authFetch = async (input: RequestInfo, init?: RequestInit): Promise<Response> => {
         const token = await tp.getToken();
@@ -72,7 +76,7 @@ export const createAuthProvider = <T>({
         return [isLogged] as [typeof isLogged];
     };
 
-    return [useAuth, authFetch, login, logout] as [typeof useAuth, typeof authFetch, typeof login, typeof logout];
+    return [useAuth, authFetch, login, logout, getToken] as [typeof useAuth, typeof authFetch, typeof login, typeof logout, typeof getToken];
 };
 
 interface ITokenProviderConfig<T> {


### PR DESCRIPTION
I'm planning on using this with the Apollo GraphQL client rather than the provided authFetch so I need a way to get the token and I don't like the idea of going to the localStorage directly as it kind of defeats the purpose of using this package. Long story short (and as the title says), I've add a `getToken` function to the response from ` createAuthProvider`.

My thinking is that this would be used like...

```js
import {createAuthProvider} from 'react-token-auth';

const [useAuth, authFetch, login, logout, getToken] = createAuthProvider(...);

export {
  useAuth,
  login,
  logout,
  getToken
}
```

```js
import { getToken } from '@/authProvider';

// const token = await getToken();
```

Is that correct?
If not then this PR will make no sense.