### PR TITLE
checkExpiry: remove duplicated deletion of key and allow notify()

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -176,12 +176,7 @@ const createTokenProvider = <T>({
         const token = getTokenInternal();
         if (token && isExpired(getExpire(token))) {
             const newToken = onUpdateToken ? await onUpdateToken(token) : null;
-
-            if (newToken) {
-                setToken(newToken);
-            } else {
-                storage.removeItem(localStorageKey);
-            }
+            setToken(newToken);
         }
     };
 


### PR DESCRIPTION
authFetch() uses checkExpiry() and assigns newToken if it exists, via setToken, or removes the key from default storage. setToken() already does this, as well as notify() the listener if the storage key was removed (i.e. set to null and storage.removeItem). Otherwise the useAuth() is unable to detect a change and reports user isLoggedIn even when there is no 'REACT_TOKEN_AUTH_KEY' in storage.